### PR TITLE
Fixes pointer violation on CryptoAPI hash implementation

### DIFF
--- a/mini/crypto/capi/hash.inl
+++ b/mini/crypto/capi/hash.inl
@@ -258,12 +258,12 @@ hash<HASH_ALGORITHM>::init(
 
   struct blob
   {
-    BLOBHEADER header;
-    DWORD      size;
+    PUBLICKEYSTRUC header;
+    DWORD          size;
 //  BYTE       key[key.get_size()];
   };
 
-  blob* key_blob = reinterpret_cast<byte_type*>(new byte_type[sizeof(blob) + key.get_size()]);
+  blob* key_blob = reinterpret_cast<blob*>(new byte_type[sizeof(blob) + key.get_size()]);
   key_blob->header.bType = PLAINTEXTKEYBLOB;
   key_blob->header.bVersion = CUR_BLOB_VERSION;
   key_blob->header.reserved = 0;
@@ -271,14 +271,14 @@ hash<HASH_ALGORITHM>::init(
   key_blob->size = static_cast<DWORD>(key.get_size());
 
   memory::copy(
-    reinterpret_cast<byte_type*>(&key_blob) + sizeof(blob),
+    reinterpret_cast<byte_type*>(key_blob) + sizeof(blob),
     key.get_buffer(),
     key_blob->size);
 
   CryptImportKey(
     provider_factory.get_rsa_aes_handle(),
-    (PBYTE)&key_blob,
-    sizeof(blob) + static_cast<DWORD>(key.get_size()),
+    (PBYTE) key_blob,
+    sizeof(blob) + key_blob->size,
     0,
     CRYPT_IPSEC_HMAC_KEY,
     &key_handle);

--- a/mini/crypto/capi/hash.inl
+++ b/mini/crypto/capi/hash.inl
@@ -263,7 +263,8 @@ hash<HASH_ALGORITHM>::init(
 //  BYTE       key[key.get_size()];
   };
 
-  blob* key_blob = reinterpret_cast<blob*>(new byte_type[sizeof(blob) + key.get_size()]);
+  size_t n = sizeof(blob) + key.get_size();
+  blob* key_blob = reinterpret_cast<blob*>(new byte_type[n]);
   key_blob->header.bType = PLAINTEXTKEYBLOB;
   key_blob->header.bVersion = CUR_BLOB_VERSION;
   key_blob->header.reserved = 0;
@@ -278,7 +279,7 @@ hash<HASH_ALGORITHM>::init(
   CryptImportKey(
     provider_factory.get_rsa_aes_handle(),
     (PBYTE) key_blob,
-    sizeof(blob) + key_blob->size,
+    n,
     0,
     CRYPT_IPSEC_HMAC_KEY,
     &key_handle);


### PR DESCRIPTION
✅ Fixes https://github.com/wbenny/mini-tor/issues/9

Line 274 is definitely a problem, someone must have had thought `key_blob` was a reference to the public key blob, which is, in fact, a full-blown pointer and hence created a double reference to the key blob.

Is this supposed to be a team project where multiple high-and-low talents worked together so that the code is somewhat mixed in quality? I have see very little null checks here, I supposed this is worked out under the assumption that they all should work humbly?