### PR TITLE
Use GMT time instead of local time

### DIFF
--- a/mini/crt/msvcrt.def
+++ b/mini/crt/msvcrt.def
@@ -51,7 +51,7 @@ EXPORTS
 ;
 
   time
-  mktime
+  _mkgmtime
 
 ;
 ; CRT

--- a/mini/time.cpp
+++ b/mini/time.cpp
@@ -24,7 +24,7 @@ time(
 
 extern "C"
 uint32_t __cdecl
-mktime(
+_mkgmtime(
   struct tm* timeptr
   );
 
@@ -78,7 +78,7 @@ time::parse(
   system_time.tm_mon  -=     1;
   system_time.tm_isdst =    -1;
 
-  _timestamp = mktime(&system_time);
+  _timestamp = _mkgmtime(&system_time);
 }
 
 uint32_t


### PR DESCRIPTION
This fixes wrong interpretation of `valid-after` field of TOR consensus database.